### PR TITLE
viewletmanager.viewlets should be a list

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,9 @@ Changes
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- viewletmanager.viewlets should be a list so we can iterate over it several
+  times in consumer code instead of having to remember it's an iterable we can
+  only list once.
 
 3.0.1 (2018-01-12)
 ------------------

--- a/src/grokcore/viewlet/components.py
+++ b/src/grokcore/viewlet/components.py
@@ -66,7 +66,7 @@ class ViewletManager(ViewletManagerBase):
         super(ViewletManager, self).update()
         # Filter out the unavailable viewlets *after* the viewlet's update()
         # has been called.
-        self.viewlets = filter(lambda v: v.available(), self.viewlets)
+        self.viewlets = [v for v in self.viewlets if v.available()]
 
     def render(self):
         """See zope.contentprovider.interfaces.IContentProvider"""

--- a/src/grokcore/viewlet/tests/functional/viewlet/viewletmanager_template.py
+++ b/src/grokcore/viewlet/tests/functional/viewlet/viewletmanager_template.py
@@ -48,9 +48,8 @@ class CaveManager(grok.ViewletManager):
 
     def update(self):
         super(CaveManager, self).update()
-        viewlets = list(self.viewlets)
         self.viewlet_dict = {}
-        for v in viewlets:
+        for v in self.viewlets:
             self.viewlet_dict[v.__name__] = v
         self.viewlet_keys_sorted = sorted(self.viewlet_dict.keys())
 


### PR DESCRIPTION
so we can iterate over it several times in consumer code instead of having to remember it's an iterable we can
only list once.